### PR TITLE
Updates in `Present` to render stack tree for `Dev.wtf`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 0.8.4
+* Update `Present` to render `Developer.wtf?` for given activity fearlessly
+
 # 0.8.3
 
 * Use `Context.for` to create contexts.

--- a/lib/trailblazer/activity/present.rb
+++ b/lib/trailblazer/activity/present.rb
@@ -11,29 +11,33 @@ module Trailblazer
         INDENTATION = "   |".freeze
         STEP_PREFIX = "-- ".freeze
 
-        def default_renderer(stack:, level:, input:, name:, **)
-          [ level, %{#{name}} ]
+        def default_renderer(task_node:, **)
+          [ task_node[:level], %{#{task_node[:name]}} ]
         end
 
         def call(stack, level: 1, tree: [], renderer: method(:default_renderer), **options)
           tree(stack.to_a, level, tree: tree, renderer: renderer, **options)
         end
 
-        def tree(stack, level, tree:, **options)
+        def tree(stack, level, tree:, renderer:, **options)
           tree_for(stack, level, options.merge(tree: tree))
 
-          render_tree(tree: tree, level: level)
+          nodes = tree.each_with_index.map do |task_node, position|
+            renderer.(task_node: task_node, position: position, tree: tree)
+          end
+
+          render_tree_for(nodes)
         end
 
-        def render_tree(tree:, level:)
-          tree.map { |level, step|
+        def render_tree_for(nodes)
+          nodes.map { |level, node|
             indentation = INDENTATION * (level -1)
-            indentation = indentation[0...-1] + "`" if level == 1 || /End./.match(step) # start or end step
-            indentation + STEP_PREFIX + step
+            indentation = indentation[0...-1] + "`" if level == 1 || /End./.match(node) # start or end step
+            indentation + STEP_PREFIX + node
           }.join("\n")
         end
 
-        def tree_for(stack, level, tree:, renderer:, **options)
+        def tree_for(stack, level, tree:, **options)
           stack.each do |lvl| # always a Stack::Task[input, ..., output]
             input, output, nested = Trace::Level.input_output_nested_for_level(lvl)
 
@@ -44,33 +48,14 @@ module Trailblazer
             name = (node = graph.find { |node| node[:task] == task }) ? node[:id] : task
             name ||= task # FIXME: bullshit
 
-            tree << renderer.(stack: stack, level: level, input: input, name: name, **options)
+            tree << { level: level, input: input, output: output, name: name, **options }
 
             if nested.any? # nesting
-              tree_for(nested, level + 1, options.merge(tree: tree, renderer: renderer))
+              tree_for(nested, level + 1, options.merge(tree: tree))
             end
 
             tree
           end
-        end
-
-        def color_map
-          {
-            Trailblazer::Activity::Start => :blue,
-            Trailblazer::Activity::End   => :pink,
-            Trailblazer::Activity::Right => :green,
-            Trailblazer::Activity::Left  => :red
-          }
-        end
-
-        def color_table
-          {
-            red:    31,
-            green:  32,
-            yellow: 33,
-            blue:   34,
-            pink:   35
-          }
         end
       end
     end

--- a/lib/trailblazer/activity/version.rb
+++ b/lib/trailblazer/activity/version.rb
@@ -1,7 +1,7 @@
 module Trailblazer
   module Version
     module Activity
-      VERSION = "0.8.3"
+      VERSION = "0.8.4"
     end
   end
 end

--- a/test/wrap/trace_test.rb
+++ b/test/wrap/trace_test.rb
@@ -59,7 +59,14 @@ class TraceTest < Minitest::Spec
       ]
     )
 
-    renderer = ->(level:, input:, name:, color:, **) { [level, %{#{level}/#{input.task}/#{name}/#{color}}] }
+    renderer = ->(task_node:, position:, tree:) do
+      assert tree[position] == task_node
+
+      [
+        task_node[:level],
+        %{#{task_node[:level]}/#{task_node[:input].task}/#{task_node[:output].data}/#{task_node[:name]}/#{task_node[:color]}}
+      ]
+    end
 
     output = Trailblazer::Activity::Trace::Present.(stack, renderer: renderer,
       color: "pink" # additional options.
@@ -67,16 +74,16 @@ class TraceTest < Minitest::Spec
 
     output = output.gsub(/0x\w+/, "").gsub(/0x\w+/, "").gsub(/@.+_test/, "")
 
-    output.must_equal %{`-- 1/#<Trailblazer::Activity:>/#<Trailblazer::Activity:>/pink
-   |-- 2/#<Trailblazer::Activity::Start semantic=:default>/Start.default/pink
-   |-- 2/#<Method: #<Module:>.b>/B/pink
-   |-- 2/#<Trailblazer::Activity:>/D/pink
-   |   |-- 3/#<Trailblazer::Activity::Start semantic=:default>/Start.default/pink
-   |   |-- 3/#<Method: #<Module:>.b>/B/pink
-   |   |-- 3/#<Method: #<Module:>.c>/C/pink
-   |   `-- 3/#<Trailblazer::Activity::End semantic=:success>/End.success/pink
-   |-- 2/#<Method: #<Module:>.f>/E/pink
-   `-- 2/#<Trailblazer::Activity::End semantic=:success>/End.success/pink}
+    output.must_equal %{`-- 1/#<Trailblazer::Activity:>/#<Trailblazer::Activity::End semantic=:success>/#<Trailblazer::Activity:>/pink
+   |-- 2/#<Trailblazer::Activity::Start semantic=:default>/Trailblazer::Activity::Right/Start.default/pink
+   |-- 2/#<Method: #<Module:>.b>/Trailblazer::Activity::Right/B/pink
+   `-- 2/#<Trailblazer::Activity:>/#<Trailblazer::Activity::End semantic=:success>/D/pink
+   |   |-- 3/#<Trailblazer::Activity::Start semantic=:default>/Trailblazer::Activity::Right/Start.default/pink
+   |   |-- 3/#<Method: #<Module:>.b>/Trailblazer::Activity::Right/B/pink
+   |   |-- 3/#<Method: #<Module:>.c>/Trailblazer::Activity::Right/C/pink
+   |   `-- 3/#<Trailblazer::Activity::End semantic=:success>/#<Trailblazer::Activity::End semantic=:success>/End.success/pink
+   |-- 2/#<Method: #<Module:>.f>/Trailblazer::Activity::Right/E/pink
+   `-- 2/#<Trailblazer::Activity::End semantic=:success>/#<Trailblazer::Activity::End semantic=:success>/End.success/pink}
   end
 
   it "allows to inject custom :stack" do


### PR DESCRIPTION
- Update `Present.tree` to collect step input and output
- Pass previous and next steps to tree `renderer` including current step, to colorize trace in `Dev.wtf`.
- Refer https://github.com/trailblazer/trailblazer-developer/pull/11 about how new `renderer` API is getting used